### PR TITLE
fix: default to accepting new ssh host key fingerprints

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -28,6 +28,7 @@ module.exports = () => {
     return gitEnv
   }, {
     GIT_ASKPASS: 'echo',
-    GIT_TEMPLATE_DIR: tmpName
+    GIT_TEMPLATE_DIR: tmpName,
+    GIT_SSH_COMMAND: 'ssh -oStrictHostKeyChecking=accept-new'
   })
 }


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

currently, if a user tries to use npm to install a git repository over ssh from a host that does not already exist in their `~/.ssh/known_hosts` a prompt is half displayed and the install appears to hang. pressing enter when this happens does unblock the install, but the behavior is super strange.

this change requires a git version > 2.3 and an openssh version > 7.6 but is a reasonably safe default as it will accept new host fingerprints without prompting, but hosts that exist in your `~/.ssh/known_hosts` will be verified and fail if they mismatch.

this default behavior can be overridden by either of
- configuring `core.sshCommand` in your `~/.gitconfig`
- exporting your own value for `GIT_SSH_COMMAND`

I'll see if I can get an installation of something up and running with an older openssh to see how it's handled if the `accept-new` value isn't supported. older versions of git aren't a concern since they would simply ignore the env var and maintain the current behavior.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Related to https://github.com/npm/cli/issues/2741