### PR TITLE
Fixes #10 and npm/cli#2414

### DIFF
--- a/lib/clone.js
+++ b/lib/clone.js
@@ -44,6 +44,10 @@ const maybeShallow = (repo, opts) =>
 
 const isWindows = opts => (opts.fakePlatform || process.platform) === 'win32'
 
+const escapeTarget = (target, opts) =>
+  isWindows(opts) && target && !target.match(/^"/) ? '"' + target + '"'
+    : target
+
 const defaultTarget = (repo, /* istanbul ignore next */ cwd = process.cwd()) =>
   resolve(cwd, basename(repo.replace(/[\/\\]?\.git$/, '')))
 
@@ -92,7 +96,7 @@ const branch = (repo, revDoc, target, opts) => {
     '-b',
     revDoc.ref,
     repo,
-    target,
+    escapeTarget(target, opts),
     '--recurse-submodules',
   ]
   if (maybeShallow(repo, opts))
@@ -107,7 +111,7 @@ const plain = (repo, revDoc, target, opts) => {
   const args = [
     'clone',
     repo,
-    target,
+    escapeTarget(target, opts),
     '--recurse-submodules'
   ]
   if (maybeShallow(repo, opts))
@@ -131,7 +135,7 @@ const unresolved = (repo, ref, target, opts) => {
   // can't do this one shallowly, because the ref isn't advertised
   // but we can avoid checking out the working dir twice, at least
   const lp = isWindows(opts) ? ['--config', 'core.longpaths=true'] : []
-  const cloneArgs = ['clone', '--mirror', '-q', repo, target + '/.git']
+  const cloneArgs = ['clone', '--mirror', '-q', repo, escapeTarget(target + '/.git', opts)]
   const git = (args) => spawn(args, { ...opts, cwd: target })
   return mkdirp(target)
     .then(() => git(cloneArgs.concat(lp)))


### PR DESCRIPTION
<!-- What / Why -->
Escapes windows target path to ensure it works even when it contains spaces
<!-- Describe the request in detail. What it does and why it's being changed. -->
https://github.com/npm/cli/issues/2414 contains the issue at hand. A minimal use case can be provided, if necessary, to illustrate both the bug being solved and the correction of the fix.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Closes #10 
Closes npm/cli#2414