### PR TITLE
fix(test): Fixes test/spawn.js on Windows

### DIFF
--- a/test/spawn.js
+++ b/test/spawn.js
@@ -20,7 +20,7 @@ t.test('setup repo', t => {
   t.teardown(() => process.chdir(cwd))
   process.chdir(repo)
   return t.resolveMatch(spawn(['init']),
-    { stdout: `Initialized empty Git repository in ${slash(repo)}` })
+    { stdout: `Initialized empty Git repository in ${slash(fs.realpathSync.native(repo))}` })
 })
 
 t.test('retries', t => {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Without normalizing the path the test fails on Windows because (spawn(['init']) returns the path in a different case the test expects.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes npm#11
