### PR TITLE
fix(test): Increase timeout on test/clone.js

### DIFF
--- a/test/clone.js
+++ b/test/clone.js
@@ -22,6 +22,7 @@ const repo = resolve(me, 'repo')
 let repoSha = ''
 let submodsRepoSha = ''
 
+t.setTimeout(60000)
 t.test('create repo', { bail: true }, t => {
   const git = (...cmd) => spawnGit(cmd, { cwd: repo })
   const write = (f, c) => fs.writeFileSync(`${repo}/${f}`, c)


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This fix increases the timeout on test/clone.js from the default 30s to 60s to allow for underpowered or otherwise slower machines / OS to complete the test successfully

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Closes https://github.com/npm/git/issues/15