### PR TITLE
fix(test): fixes is-clean test leftover folder

### DIFF
--- a/test/is-clean.js
+++ b/test/is-clean.js
@@ -2,32 +2,34 @@ const isClean = require('../lib/is-clean.js')
 const spawn = require('../lib/spawn.js')
 const t = require('tap')
 
-const cwd = t.testdir()
+const repo = t.testdir()
 const { resolve } = require('path')
 const { promisify } = require('util')
 const writeFile = promisify(require('fs').writeFile)
-const write = (file, data) => writeFile(resolve(cwd, file), data)
+const write = (file, data) => writeFile(resolve(repo, file), data)
 
 t.test('create git repo', t =>
-  spawn(['init'], { cwd })
+  spawn(['init'], { cwd: repo })
   .then(() => write('hello', 'world')))
 
 t.test('dir is clean, just one unknown file', t =>
-  t.resolveMatch(isClean({cwd}), true))
+  t.resolveMatch(isClean({cwd: repo}), true))
 
 t.test('add the file, no longer clean', t =>
-  spawn(['add', 'hello'], { cwd })
-  .then(() => t.resolveMatch(isClean({cwd}), false)))
+  spawn(['add', 'hello'], { cwd: repo })
+  .then(() => t.resolveMatch(isClean({cwd: repo}), false)))
 
 t.test('commit the file, clean again', t =>
-  spawn(['commit', '-m', 'x'], { cwd })
-  .then(() => t.resolveMatch(isClean({cwd}), true)))
+  spawn(['commit', '-m', 'x'], { cwd: repo })
+  .then(() => t.resolveMatch(isClean({cwd: repo}), true)))
 
 t.test('edit the file, unclean again', t =>
   write('hello', 'goodbye')
-  .then(() => t.resolveMatch(isClean({cwd}), false)))
+  .then(() => t.resolveMatch(isClean({cwd: repo}), false)))
 
-t.test('default to cwd', t => {
-  process.chdir(cwd)
+t.test('default to repo', t => {
+  const cwd = process.cwd()
+  t.teardown(() => process.chdir(cwd))
+  process.chdir(repo)
   return t.resolveMatch(isClean(), false)
 })


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
On Windows, this test was leaving a test/is-clean leftover folder after concluding the tests, caused by process.chdir preventing windows from deleting the temporary folder by virtue of being in use.


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Closes #17 