### PR TITLE
test: Usecase for clone using cmd shell on Win32

### DIFF
--- a/test/clone.js
+++ b/test/clone.js
@@ -246,3 +246,8 @@ if ((process.platform) === 'win32') {
     .then((r) => revs(clonedRepoSpaces2).then((r2) => t.same(Object.keys(r.shas), Object.keys(r2.shas))))
   )
 }
+else {
+  t.test('cloning to folder with spaces with cmd as the shell not on windows', t => 
+    t.rejects(clone(join(regularRepo, '.git'), 'HEAD', clonedRepoSpaces2, { fakePlatform: 'win32', shell: 'cmd' })) )
+}
+

--- a/test/clone.js
+++ b/test/clone.js
@@ -1,19 +1,22 @@
 const clone = require('../lib/clone.js')
+const revs = require('../lib/revs.js')
 
 const t = require('tap')
 const fs = require('fs')
 const {spawn} = require('child_process')
 const rimraf = require('rimraf')
 const { promisify } = require('util')
-const { resolve } = require('path')
+const { resolve, join } = require('path')
 const mkdirp = require('mkdirp')
 
 const port = 12345 + (+process.env.TAP_CHILD_ID || 0)
 const spawnGit = require('../lib/spawn.js')
 t.saveFixture = true
+const regularRepoDir = 'regular-folder';
 const me = t.testdir({
   'submodule-repo': {},
   repo: {},
+  [ regularRepoDir ]: {},
 })
 const remote = `git://localhost:${port}/repo`
 const submodsRemote = `git://localhost:${port}/submodule-repo`
@@ -206,3 +209,40 @@ t.test('again, with a submodule', t => {
     }))
   }))
 })
+
+const clonedRepoDir = 'cloned-folder';
+const clonedSpacesRepoDir = 'cloned folder with spaces';
+const clonedSpacesRepoDir2 = 'cloned folder with spaces too';
+
+const regularRepo = join(me, regularRepoDir);
+const clonedRepo = join(me, clonedRepoDir);
+const clonedRepoSpaces = join(me, clonedSpacesRepoDir);
+const clonedRepoSpaces2 = join(me, clonedSpacesRepoDir2);
+
+t.test('setup aditional tests', t => {
+  const git = (...cmd) => spawnGit(cmd, { cwd: regularRepo })
+  const write = (f, c) => fs.writeFileSync(`${regularRepo}/${f}`, c)
+  return git('init')
+  .then(() => write('foo', 'bar'))
+  .then(() => git('add', 'foo'))
+  .then(() => git('commit', '-m', 'foobar'))
+})
+
+t.test('cloning to regular folder', t =>
+  clone(join(regularRepo, '.git'), 'HEAD', clonedRepo)
+  .then(() => revs(regularRepo))
+  .then((r) => revs(clonedRepo).then((r2) => t.same(Object.keys(r.shas), Object.keys(r2.shas))))
+)
+t.test('cloning to folder with spaces', t =>
+  clone(join(regularRepo, '.git'), 'HEAD', clonedRepoSpaces)
+  .then(() => revs(regularRepo))
+  .then((r) => revs(clonedRepoSpaces).then((r2) => t.same(Object.keys(r.shas), Object.keys(r2.shas))))
+)
+
+if ((process.platform) === 'win32') {
+  t.test('cloning to folder with spaces with cmd as the shell on windows', t =>
+    clone(join(regularRepo, '.git'), 'HEAD', clonedRepoSpaces2, { shell: 'cmd' })
+    .then(() => revs(regularRepo))
+    .then((r) => revs(clonedRepoSpaces2).then((r2) => t.same(Object.keys(r.shas), Object.keys(r2.shas))))
+  )
+}


### PR DESCRIPTION
<!-- What / Why -->
New usecase for clone.js

<!-- Describe the request in detail. What it does and why it's being changed. -->
It confirms the reason for certain bugs (see below) affecting the clone of repositories to destinations containing on Windows and will validate the fix

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Related to #10 
Related to https://github.com/npm/cli/issues/2414 
Depends on #20 