### PR TITLE
fix(utils.escapePath): better checking for cmd

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,15 +1,16 @@
+const { basename } = require('path')
+
 const isWindows = opts => (opts.fakePlatform || process.platform) === 'win32'
 
-// wrap the target in quotes for Windows when using cmd.exe as a shell
-// to avoid clone failures for paths with spaces
-const escapePath = (path, opts) => {
-  if (isWindows(opts) && /cmd(\.exe)?$/i.test(opts.shell) && !path.startsWith('"')) {
-    return `"${path}"`
+// wrap the target in quotes for Windows when using cmd(.exe) as a shell to
+// avoid clone failures for paths with spaces
+const escapePath = (gitPath, opts) => {
+  const isCmd = opts.shell && (basename(opts.shell.toLowerCase(), '.exe') === 'cmd')
+  if (isWindows(opts) && isCmd && !gitPath.startsWith('"')) {
+    return `"${gitPath}"`
   }
-  return path
+  return gitPath
 }
 
-module.exports = {
-  isWindows,
-  escapePath
-}
+exports.escapePath = escapePath
+exports.isWindows = isWindows


### PR DESCRIPTION
As per discussion here:
https://github.com/npm/git/commit/0038a9dbd56f5a550a4cab1a996eda5e67243680