### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/lines-to-revs.js
+++ b/lib/lines-to-revs.js
@@ -98,19 +98,19 @@ const lineToRevDoc = line => {
     // ignore the pointer.
     // For now, though, we have to save both, because some tags
     // don't have peels, if they were not annotated.
-    const ref = rawRef.substr('refs/tags/'.length)
+    const ref = rawRef.slice('refs/tags/'.length)
     return { sha, ref, rawRef, type }
   }
 
   if (type === 'branch') {
-    const ref = rawRef.substr('refs/heads/'.length)
+    const ref = rawRef.slice('refs/heads/'.length)
     return { sha, ref, rawRef, type }
   }
 
   if (type === 'pull') {
     // NB: merged pull requests installable with #pull/123/merge
     // for the merged pr, or #pull/123 for the PR head
-    const ref = rawRef.substr('refs/'.length).replace(/\/head$/, '')
+    const ref = rawRef.slice('refs/'.length).replace(/\/head$/, '')
     return { sha, ref, rawRef, type }
   }
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.