### PR TITLE
fix: accessing undefined variable on repos without HEAD reference

### DIFF
--- a/lib/clone.js
+++ b/lib/clone.js
@@ -54,7 +54,7 @@ const clone = (repo, revs, ref, revDoc, target, opts) => {
   if (!revDoc) {
     return unresolved(repo, ref, target, opts)
   }
-  if (revDoc.sha === revs.refs.HEAD.sha) {
+  if (revDoc.sha === revs?.refs?.HEAD?.sha) {
     return plain(repo, revDoc, target, opts)
   }
   if (revDoc.type === 'tag' || revDoc.type === 'branch') {


### PR DESCRIPTION

<!-- What / Why -->
NPM install failed when a repo did not have a HEAD reference.
Git Server: gitea 1.17.1

<!-- Describe the request in detail. What it does and why it's being changed. -->
The changes just allow for null/undefined safe variable accessing in the ES2020 format(optional chaining)

## References
<!-- Examples:
  Fixes #116
-->
