### PR TITLE
fix: lazy load of which module

### DIFF
--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -2,10 +2,10 @@ const spawn = require('@npmcli/promise-spawn')
 const promiseRetry = require('promise-retry')
 const log = require('proc-log')
 const makeError = require('./make-error.js')
-const whichGit = require('./which.js')
 const makeOpts = require('./opts.js')
 
 module.exports = (gitArgs, opts = {}) => {
+  const whichGit = require('./which.js')
   const gitPath = whichGit(opts)
 
   if (gitPath instanceof Error) {

--- a/lib/which.js
+++ b/lib/which.js
@@ -1,15 +1,13 @@
-let gitPath
-module.exports = (opts = {}) => {
-  if (!gitPath) {
-    try {
-      // inline lazy require to avoid unnecessary perf cost when requiring @npmcli/git 
-      const which = require('which')
-      gitPath = which.sync('git')
-    } catch {
-      // ignore errors
-    }
-  }
+const which = require('which')
 
+let gitPath
+try {
+  gitPath = which.sync('git')
+} catch {
+  // ignore errors
+}
+
+module.exports = (opts = {}) => {
   if (opts.git) {
     return opts.git
   }

--- a/lib/which.js
+++ b/lib/which.js
@@ -1,13 +1,15 @@
-const which = require('which')
-
 let gitPath
-try {
-  gitPath = which.sync('git')
-} catch {
-  // ignore errors
-}
-
 module.exports = (opts = {}) => {
+  if (!gitPath) {
+    try {
+      // inline lazy require to avoid unnecessary perf cost when requiring @npmcli/git 
+      const which = require('which')
+      gitPath = which.sync('git')
+    } catch {
+      // ignore errors
+    }
+  }
+
   if (opts.git) {
     return opts.git
   }


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Currently `@npmcli/git` is eagerly getting and caching the `git` path in a user's system which can have a significant performance cost when requiring `@npmcli/git`. This PR avoids this cost by lazily getting & caching `git` path on first use.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
