### PR TITLE
fix: smarter git ssh override

### DIFF
--- a/lib/opts.js
+++ b/lib/opts.js
@@ -9,14 +9,12 @@ let cachedConfig = null
 
 // Function to load and cache the git config
 const loadGitConfig = () => {
-  /* istanbul ignore next */
   if (cachedConfig === null) {
     try {
+      cachedConfig = {}
       if (fs.existsSync(gitConfigPath)) {
         const configContent = fs.readFileSync(gitConfigPath, 'utf-8')
         cachedConfig = ini.parse(configContent)
-      } else {
-        cachedConfig = {}
       }
     } catch (error) {
       cachedConfig = {}
@@ -28,8 +26,8 @@ const loadGitConfig = () => {
 const checkGitConfigs = () => {
   const config = loadGitConfig()
   return {
-    sshCommandSetInConfig: config.core?.sshCommand !== undefined,
-    askPassSetInConfig: config.core?.askpass !== undefined,
+    sshCommandSetInConfig: config?.core?.sshCommand !== undefined,
+    askPassSetInConfig: config?.core?.askpass !== undefined,
   }
 }
 
@@ -55,6 +53,5 @@ module.exports = (opts = {}) => ({
   env: opts.env || { ...finalGitEnv, ...process.env },
 })
 
-module.exports._resetCachedConfig = () => {
-  cachedConfig = null
-}
+// Export the loadGitConfig function for testing
+module.exports.loadGitConfig = loadGitConfig

--- a/lib/opts.js
+++ b/lib/opts.js
@@ -1,34 +1,37 @@
-const fs = require('fs')
-const os = require('os')
-const path = require('path')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
 const ini = require('ini')
 
 const gitConfigPath = path.join(os.homedir(), '.gitconfig')
 
-// Function to check if sshCommand is set in the git config
-const isGitSshCommandSetInConfig = () => {
-  try {
-    if (fs.existsSync(gitConfigPath)) {
-      const config = ini.parse(fs.readFileSync(gitConfigPath, 'utf-8'))
-      return config.core && config.core.sshCommand !== undefined
+let cachedConfig = null
+
+// Function to load and cache the git config
+const loadGitConfig = () => {
+  if (cachedConfig === null) {
+    try {
+      if (fs.existsSync(gitConfigPath)) {
+        const configContent = fs.readFileSync(gitConfigPath, 'utf-8')
+        cachedConfig = ini.parse(configContent)
+      } else {
+        cachedConfig = {}
+      }
+    } catch (error) {
+      cachedConfig = {}
     }
-  } catch (error) {
-    return false
   }
-  return false
+  return cachedConfig
 }
 
-// Function to check if askpass is set in the git config
+const isGitSshCommandSetInConfig = () => {
+  const config = loadGitConfig()
+  return config.core && config.core.sshCommand !== undefined
+}
+
 const isGitAskPassSetInConfig = () => {
-  try {
-    if (fs.existsSync(gitConfigPath)) {
-      const config = ini.parse(fs.readFileSync(gitConfigPath, 'utf-8'))
-      return config.core && config.core.askpass !== undefined
-    }
-  } catch (error) {
-    return false
-  }
-  return false
+  const config = loadGitConfig()
+  return config.core && config.core.askpass !== undefined
 }
 
 module.exports = (opts = {}) => {

--- a/lib/opts.js
+++ b/lib/opts.js
@@ -1,12 +1,8 @@
 // Values we want to set if they're not already defined by the end user
-// This defaults to accepting new ssh host key fingerprints
-const gitEnv = {
-  GIT_ASKPASS: 'echo',
-  GIT_SSH_COMMAND: 'ssh -oStrictHostKeyChecking=accept-new',
-}
+const defaultEnv = {}
 module.exports = (opts = {}) => ({
   stdioString: true,
   ...opts,
   shell: false,
-  env: opts.env || { ...gitEnv, ...process.env },
+  env: opts.env || { ...defaultEnv, ...process.env },
 })

--- a/lib/opts.js
+++ b/lib/opts.js
@@ -9,6 +9,7 @@ let cachedConfig = null
 
 // Function to load and cache the git config
 const loadGitConfig = () => {
+  /* istanbul ignore next */
   if (cachedConfig === null) {
     try {
       if (fs.existsSync(gitConfigPath)) {
@@ -24,37 +25,36 @@ const loadGitConfig = () => {
   return cachedConfig
 }
 
-const isGitSshCommandSetInConfig = () => {
+const checkGitConfigs = () => {
   const config = loadGitConfig()
-  return config.core && config.core.sshCommand !== undefined
-}
-
-const isGitAskPassSetInConfig = () => {
-  const config = loadGitConfig()
-  return config.core && config.core.askpass !== undefined
-}
-
-module.exports = (opts = {}) => {
-  const sshCommandSetInEnv = process.env.GIT_SSH_COMMAND !== undefined
-  const sshCommandSetInConfig = isGitSshCommandSetInConfig()
-  const askPassSetInEnv = process.env.GIT_ASKPASS !== undefined
-  const askPassSetInConfig = isGitAskPassSetInConfig()
-
-  // Values we want to set if they're not already defined by the end user
-  // This defaults to accepting new ssh host key fingerprints
-  const finalGitEnv = {
-    ...(askPassSetInEnv || askPassSetInConfig ? {} : {
-      GIT_ASKPASS: 'echo',
-    }),
-    ...(sshCommandSetInEnv || sshCommandSetInConfig ? {} : {
-      GIT_SSH_COMMAND: 'ssh -oStrictHostKeyChecking=accept-new',
-    }),
-  }
-
   return {
-    stdioString: true,
-    ...opts,
-    shell: false,
-    env: opts.env || { ...finalGitEnv, ...process.env },
+    sshCommandSetInConfig: config.core?.sshCommand !== undefined,
+    askPassSetInConfig: config.core?.askpass !== undefined,
   }
+}
+
+const sshCommandSetInEnv = process.env.GIT_SSH_COMMAND !== undefined
+const askPassSetInEnv = process.env.GIT_ASKPASS !== undefined
+const { sshCommandSetInConfig, askPassSetInConfig } = checkGitConfigs()
+
+// Values we want to set if they're not already defined by the end user
+// This defaults to accepting new ssh host key fingerprints
+const finalGitEnv = {
+  ...(askPassSetInEnv || askPassSetInConfig ? {} : {
+    GIT_ASKPASS: 'echo',
+  }),
+  ...(sshCommandSetInEnv || sshCommandSetInConfig ? {} : {
+    GIT_SSH_COMMAND: 'ssh -oStrictHostKeyChecking=accept-new',
+  }),
+}
+
+module.exports = (opts = {}) => ({
+  stdioString: true,
+  ...opts,
+  shell: false,
+  env: opts.env || { ...finalGitEnv, ...process.env },
+})
+
+module.exports._resetCachedConfig = () => {
+  cachedConfig = null
 }

--- a/lib/opts.js
+++ b/lib/opts.js
@@ -1,8 +1,57 @@
-// Values we want to set if they're not already defined by the end user
-const defaultEnv = {}
-module.exports = (opts = {}) => ({
-  stdioString: true,
-  ...opts,
-  shell: false,
-  env: opts.env || { ...defaultEnv, ...process.env },
-})
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const ini = require('ini')
+
+const gitConfigPath = path.join(os.homedir(), '.gitconfig')
+
+// Function to check if sshCommand is set in the git config
+const isGitSshCommandSetInConfig = () => {
+  try {
+    if (fs.existsSync(gitConfigPath)) {
+      const config = ini.parse(fs.readFileSync(gitConfigPath, 'utf-8'))
+      return config.core && config.core.sshCommand !== undefined
+    }
+  } catch (error) {
+    return false
+  }
+  return false
+}
+
+// Function to check if askpass is set in the git config
+const isGitAskPassSetInConfig = () => {
+  try {
+    if (fs.existsSync(gitConfigPath)) {
+      const config = ini.parse(fs.readFileSync(gitConfigPath, 'utf-8'))
+      return config.core && config.core.askpass !== undefined
+    }
+  } catch (error) {
+    return false
+  }
+  return false
+}
+
+module.exports = (opts = {}) => {
+  const sshCommandSetInEnv = process.env.GIT_SSH_COMMAND !== undefined
+  const sshCommandSetInConfig = isGitSshCommandSetInConfig()
+  const askPassSetInEnv = process.env.GIT_ASKPASS !== undefined
+  const askPassSetInConfig = isGitAskPassSetInConfig()
+
+  // Values we want to set if they're not already defined by the end user
+  // This defaults to accepting new ssh host key fingerprints
+  const finalGitEnv = {
+    ...(askPassSetInEnv || askPassSetInConfig ? {} : {
+      GIT_ASKPASS: 'echo',
+    }),
+    ...(sshCommandSetInEnv || sshCommandSetInConfig ? {} : {
+      GIT_SSH_COMMAND: 'ssh -oStrictHostKeyChecking=accept-new',
+    }),
+  }
+
+  return {
+    stdioString: true,
+    ...opts,
+    shell: false,
+    env: opts.env || { ...finalGitEnv, ...process.env },
+  }
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "@npmcli/template-oss": "4.22.0",
     "npm-package-arg": "^11.0.0",
     "slash": "^3.0.0",
-    "tap": "^16.0.1"
+    "tap": "^16.0.1",
+    "proxyquire": "^2.1.3"
   },
   "dependencies": {
     "@npmcli/promise-spawn": "^7.0.0",
@@ -44,7 +45,6 @@
     "proc-log": "^4.0.0",
     "promise-inflight": "^1.0.1",
     "promise-retry": "^2.0.1",
-    "proxyquire": "^2.1.3",
     "semver": "^7.3.5",
     "which": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "@npmcli/template-oss": "4.22.0",
     "npm-package-arg": "^11.0.0",
     "slash": "^3.0.0",
-    "tap": "^16.0.1",
-    "proxyquire": "^2.1.3"
+    "tap": "^16.0.1"
   },
   "dependencies": {
     "@npmcli/promise-spawn": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -38,11 +38,13 @@
   },
   "dependencies": {
     "@npmcli/promise-spawn": "^7.0.0",
+    "ini": "^4.1.3",
     "lru-cache": "^10.0.1",
     "npm-pick-manifest": "^9.0.0",
     "proc-log": "^4.0.0",
     "promise-inflight": "^1.0.1",
     "promise-retry": "^2.0.1",
+    "proxyquire": "^2.1.3",
     "semver": "^7.3.5",
     "which": "^4.0.0"
   },

--- a/test/opts.js
+++ b/test/opts.js
@@ -1,9 +1,9 @@
 const t = require('tap')
 const proxyquire = require('proxyquire')
 const gitOpts = require('../lib/opts.js')
-const fs = require('fs')
-const os = require('os')
-const path = require('path')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
 
 const gitConfigPath = path.join(os.homedir(), '.gitconfig')
 
@@ -44,7 +44,7 @@ t.test('handle case when fs.existsSync throws an error', t => {
 
   // Mocking fs.existsSync to throw an error
   const gitOptsWithMockFs = proxyquire('../lib/opts.js', {
-    fs: {
+    'node:fs': {
       ...mockFs,
       existsSync: () => {
         throw new Error('Mocked error')

--- a/test/opts.js
+++ b/test/opts.js
@@ -1,38 +1,6 @@
 const t = require('tap')
 const gitOpts = require('../lib/opts.js')
 
-t.test('defaults', t => {
-  const { GIT_ASKPASS, GIT_SSH_COMMAND } = process.env
-  t.teardown(() => {
-    process.env.GIT_ASKPASS = GIT_ASKPASS
-    process.env.GIT_SSH_COMMAND = GIT_SSH_COMMAND
-  })
-  delete process.env.GIT_ASKPASS
-  delete process.env.GIT_SSH_COMMAND
-  t.match(gitOpts().env, {
-    GIT_ASKPASS: 'echo',
-    GIT_SSH_COMMAND: 'ssh -oStrictHostKeyChecking=accept-new',
-  }, 'got the git defaults we want')
-  t.equal(gitOpts().shell, false, 'shell defaults to false')
-  t.equal(gitOpts({ shell: '/bin/bash' }).shell, false, 'shell cannot be overridden')
-  t.end()
-})
-
-t.test('does not override', t => {
-  const { GIT_ASKPASS, GIT_SSH_COMMAND } = process.env
-  t.teardown(() => {
-    process.env.GIT_ASKPASS = GIT_ASKPASS
-    process.env.GIT_SSH_COMMAND = GIT_SSH_COMMAND
-  })
-  process.env.GIT_ASKPASS = 'test_askpass'
-  process.env.GIT_SSH_COMMAND = 'test_ssh_command'
-  t.match(gitOpts().env, {
-    GIT_ASKPASS: 'test_askpass',
-    GIT_SSH_COMMAND: 'test_ssh_command',
-  }, 'values already in process.env remain')
-  t.end()
-})
-
 t.test('as non-root', t => {
   process.getuid = () => 999
   t.match(gitOpts({

--- a/test/opts.js
+++ b/test/opts.js
@@ -1,8 +1,125 @@
 const t = require('tap')
+const proxyquire = require('proxyquire')
 const gitOpts = require('../lib/opts.js')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const gitConfigPath = path.join(os.homedir(), '.gitconfig')
+
+const mockFs = {
+  existsSync: () => false,
+  readFileSync: () => '',
+}
+
+// Utility function to backup and restore gitconfig
+const backupGitConfig = () => {
+  const backupPath = `${gitConfigPath}.backup`
+  if (fs.existsSync(gitConfigPath)) {
+    fs.copyFileSync(gitConfigPath, backupPath)
+    fs.unlinkSync(gitConfigPath)
+  }
+  return backupPath
+}
+
+const restoreGitConfig = (backupPath) => {
+  if (fs.existsSync(backupPath)) {
+    fs.copyFileSync(backupPath, gitConfigPath)
+    fs.unlinkSync(backupPath)
+  } else if (fs.existsSync(gitConfigPath)) {
+    fs.unlinkSync(gitConfigPath)
+  }
+}
+
+const writeGitConfig = (content) => {
+  fs.writeFileSync(gitConfigPath, content)
+}
+
+t.test('handle case when fs.existsSync throws an error', t => {
+  const { GIT_ASKPASS, GIT_SSH_COMMAND } = process.env
+  t.teardown(() => {
+    process.env.GIT_ASKPASS = GIT_ASKPASS
+    process.env.GIT_SSH_COMMAND = GIT_SSH_COMMAND
+  })
+
+  // Mocking fs.existsSync to throw an error
+  const gitOptsWithMockFs = proxyquire('../lib/opts.js', {
+    fs: {
+      ...mockFs,
+      existsSync: () => {
+        throw new Error('Mocked error')
+      },
+    },
+  })
+
+  t.match(gitOptsWithMockFs(), {
+    env: {
+      GIT_ASKPASS: 'echo',
+      GIT_SSH_COMMAND: 'ssh -oStrictHostKeyChecking=accept-new',
+    },
+    shell: false,
+  }, 'should apply defaults when fs.existsSync throws an error')
+
+  t.end()
+})
+
+t.test('defaults', t => {
+  const backupPath = backupGitConfig()
+  const { GIT_ASKPASS, GIT_SSH_COMMAND } = process.env
+  t.teardown(() => {
+    restoreGitConfig(backupPath)
+    process.env.GIT_ASKPASS = GIT_ASKPASS
+    process.env.GIT_SSH_COMMAND = GIT_SSH_COMMAND
+  })
+
+  delete process.env.GIT_ASKPASS
+  delete process.env.GIT_SSH_COMMAND
+
+  t.match(gitOpts(), {
+    env: {
+      GIT_ASKPASS: 'echo',
+      GIT_SSH_COMMAND: 'ssh -oStrictHostKeyChecking=accept-new',
+    },
+    shell: false,
+  }, 'got the git defaults we want')
+
+  t.end()
+})
+
+t.test('does not override when sshCommand is set in env', t => {
+  const backupPath = backupGitConfig()
+  const { GIT_ASKPASS, GIT_SSH_COMMAND } = process.env
+  t.teardown(() => {
+    restoreGitConfig(backupPath)
+    process.env.GIT_ASKPASS = GIT_ASKPASS
+    process.env.GIT_SSH_COMMAND = GIT_SSH_COMMAND
+  })
+
+  process.env.GIT_ASKPASS = 'test_askpass'
+  process.env.GIT_SSH_COMMAND = 'test_ssh_command'
+
+  t.match(gitOpts(), {
+    env: {
+      GIT_ASKPASS: 'test_askpass',
+      GIT_SSH_COMMAND: 'test_ssh_command',
+    },
+    shell: false,
+  }, 'values already in process.env remain')
+
+  t.end()
+})
 
 t.test('as non-root', t => {
+  const backupPath = backupGitConfig()
+  const { GIT_ASKPASS, GIT_SSH_COMMAND } = process.env
+  t.teardown(() => {
+    restoreGitConfig(backupPath)
+    process.env.GIT_ASKPASS = GIT_ASKPASS
+    process.env.GIT_SSH_COMMAND = GIT_SSH_COMMAND
+  })
+
   process.getuid = () => 999
+
   t.match(gitOpts({
     foo: 'bar',
     env: { override: 'for some reason' },
@@ -17,5 +134,32 @@ t.test('as non-root', t => {
     gid: undefined,
     abc: undefined,
   }, 'do not set uid/gid as non-root')
+
+  t.end()
+})
+
+t.test('does not override when sshCommand is set in git config', t => {
+  const backupPath = backupGitConfig()
+  const { GIT_ASKPASS, GIT_SSH_COMMAND } = process.env
+  t.teardown(() => {
+    restoreGitConfig(backupPath)
+    process.env.GIT_ASKPASS = GIT_ASKPASS
+    process.env.GIT_SSH_COMMAND = GIT_SSH_COMMAND
+  })
+
+  writeGitConfig(`
+[core]
+  askpass = echo
+  sshCommand = custom_ssh_command
+`)
+
+  t.match(gitOpts(), {
+    env: {
+      GIT_ASKPASS: 'undefined',
+      GIT_SSH_COMMAND: 'undefined',
+    },
+    shell: false,
+  }, 'sshCommand in git config remains')
+
   t.end()
 })


### PR DESCRIPTION
<!-- What / Why -->

Removing the overwriting of git ssh commands. This should not be done, and should be left to individuals using their own ssh configs. This breaks multiple usecases.

<!-- Describe the request in detail. What it does and why it's being changed. -->

Removing git ssh command that overrides local git ssh commands.

## References

https://github.com/npm/cli/issues/2891
https://github.com/npm/git/issues/193
https://github.com/npm/git/issues/129
