### PR TITLE
chore: ensure tests correctly mock environment variables before loading opts.js

### DIFF
--- a/test/opts.js
+++ b/test/opts.js
@@ -7,12 +7,13 @@ const mockFs = {
   readFileSync: () => '',
 }
 
-const gitOpts = t.mock('../lib/opts.js', {
-  'node:fs': mockFs,
-})
+let gitOpts
 
 t.beforeEach(() => {
   backupEnv()
+  gitOpts = t.mock('../lib/opts.js', {
+    'node:fs': mockFs,
+  })
 })
 
 t.afterEach(() => {


### PR DESCRIPTION
Move `t.mock()` inside `t.beforeEach()` to ensure `opts.js` reads the correct 
environment variables after `backupEnv()` clears them. This prevents tests 
from failing locally due to pre-existing environment variables like `GIT_ASKPASS`. 

I noticed while running the tests locally, mine was failing, but passing for the CI. 