### PR TITLE
deps: remove promise-inflight

### DIFF
--- a/lib/revs.js
+++ b/lib/revs.js
@@ -1,13 +1,11 @@
-const pinflight = require('promise-inflight')
 const spawn = require('./spawn.js')
 const { LRUCache } = require('lru-cache')
+const linesToRevs = require('./lines-to-revs.js')
 
 const revsCache = new LRUCache({
   max: 100,
   ttl: 5 * 60 * 1000,
 })
-
-const linesToRevs = require('./lines-to-revs.js')
 
 module.exports = async (repo, opts = {}) => {
   if (!opts.noGitRevCache) {
@@ -17,12 +15,8 @@ module.exports = async (repo, opts = {}) => {
     }
   }
 
-  return pinflight(`ls-remote:${repo}`, () =>
-    spawn(['ls-remote', repo], opts)
-      .then(({ stdout }) => linesToRevs(stdout.trim().split('\n')))
-      .then(revs => {
-        revsCache.set(repo, revs)
-        return revs
-      })
-  )
+  const { stdout } = await spawn(['ls-remote', repo], opts)
+  const revs = linesToRevs(stdout.trim().split('\n'))
+  revsCache.set(repo, revs)
+  return revs
 }


### PR DESCRIPTION
The use of promise-inflight was originally intended to prevent duplicate concurrent git ls-remote calls. However, this scenario is rare, and the performance impact of duplicate calls is minimal. The existing LRU cache already prevents redundant requests over time.

Removing promise-inflight simplifies the code and removes a dependency often cited by security linters. This does mean duplicate inflight requests are now possible, but the expected impact is negligible. Should we want to make sure they don't happen, we could inline a solution fairly easily