### PR TITLE
Replace StrictHostKeyChecking=accept-new with BatchMode=yes

### DIFF
--- a/lib/opts.js
+++ b/lib/opts.js
@@ -36,13 +36,13 @@ const askPassSetInEnv = process.env.GIT_ASKPASS !== undefined
 const { sshCommandSetInConfig, askPassSetInConfig } = checkGitConfigs()
 
 // Values we want to set if they're not already defined by the end user
-// This defaults to accepting new ssh host key fingerprints
+// This defaults to disabling user interaction with BatchMode
 const finalGitEnv = {
   ...(askPassSetInEnv || askPassSetInConfig ? {} : {
     GIT_ASKPASS: 'echo',
   }),
   ...(sshCommandSetInEnv || sshCommandSetInConfig ? {} : {
-    GIT_SSH_COMMAND: 'ssh -oStrictHostKeyChecking=accept-new',
+    GIT_SSH_COMMAND: 'ssh -o BatchMode=yes',
   }),
 }
 

--- a/test/opts.js
+++ b/test/opts.js
@@ -24,7 +24,7 @@ t.test('defaults', t => {
   t.match(gitOpts(), {
     env: {
       GIT_ASKPASS: 'echo',
-      GIT_SSH_COMMAND: 'ssh -oStrictHostKeyChecking=accept-new',
+      GIT_SSH_COMMAND: 'ssh -o BatchMode=yes',
     },
     shell: false,
   }, 'got the git defaults we want')
@@ -45,7 +45,7 @@ t.test('handle case when fs.existsSync throws an error', t => {
   t.match(gitOptsWithMockFs(), {
     env: {
       GIT_ASKPASS: 'echo',
-      GIT_SSH_COMMAND: 'ssh -oStrictHostKeyChecking=accept-new',
+      GIT_SSH_COMMAND: 'ssh -o BatchMode=yes',
     },
     shell: false,
   }, 'should apply defaults when fs.existsSync throws an error')
@@ -64,7 +64,7 @@ t.test('handle case when git config does not exist', t => {
   t.match(gitOptsWithMockFs(), {
     env: {
       GIT_ASKPASS: 'echo',
-      GIT_SSH_COMMAND: 'ssh -oStrictHostKeyChecking=accept-new',
+      GIT_SSH_COMMAND: 'ssh -o BatchMode=yes',
     },
     shell: false,
   }, 'should apply defaults when git config does not exist')


### PR DESCRIPTION
The additional setting was introduced in #7 to fix a display issue:
> a prompt is half displayed and the install appears to hang. pressing enter when this happens does unblock the install, but the behavior is super strange.

The correct fix should be to use `BatchMode`:
> If set to yes, user interaction such as password prompts and host key confirmation requests will be disabled.

## References
Related to #7
Closes #31
