### PR TITLE
Return the actual rev we cloned for all cloning strategies

### DIFF
--- a/lib/clone.js
+++ b/lib/clone.js
@@ -50,11 +50,18 @@ const defaultTarget = (repo, /* istanbul ignore next */ cwd = process.cwd()) =>
   path.resolve(cwd, path.basename(repo.replace(/[/\\]?\.git$/, '')))
 
 const clone = (repo, revs, ref, revDoc, target, opts) => {
+  const git = (args) => spawn(args, { ...opts, cwd: target })
+  return cloneStrategy(repo, revs, ref, revDoc, target, opts)
+    .then(() => git(['rev-parse', '--revs-only', 'HEAD']))
+    .then(({ stdout }) => stdout.trim())
+}
+
+const cloneStrategy = (repo, revs, ref, revDoc, target, opts) => {
   if (!revDoc) {
     return unresolved(repo, ref, target, opts)
   }
   if (revDoc.sha === revs.refs.HEAD.sha) {
-    return plain(repo, revDoc, target, opts)
+    return plain(repo, target, opts)
   }
   if (revDoc.type === 'tag' || revDoc.type === 'branch') {
     return branch(repo, revDoc, target, opts)
@@ -101,7 +108,6 @@ const other = (repo, revDoc, target, opts) => {
     .then(() => git(fetchOrigin))
     .then(() => git(['checkout', revDoc.sha]))
     .then(() => updateSubmodules(target, opts))
-    .then(() => revDoc.sha)
 }
 
 // tag or branches.  use -b
@@ -120,11 +126,11 @@ const branch = (repo, revDoc, target, opts) => {
   if (isWindows(opts)) {
     args.push('--config', 'core.longpaths=true')
   }
-  return spawn(args, opts).then(() => revDoc.sha)
+  return spawn(args, opts)
 }
 
 // just the head.  clone it
-const plain = (repo, revDoc, target, opts) => {
+const plain = (repo, target, opts) => {
   const args = [
     'clone',
     repo,
@@ -137,7 +143,7 @@ const plain = (repo, revDoc, target, opts) => {
   if (isWindows(opts)) {
     args.push('--config', 'core.longpaths=true')
   }
-  return spawn(args, opts).then(() => revDoc.sha)
+  return spawn(args, opts)
 }
 
 const updateSubmodules = async (target, opts) => {
@@ -167,6 +173,4 @@ const unresolved = (repo, ref, target, opts) => {
     .then(() => git(['init']))
     .then(() => git(['checkout', ref]))
     .then(() => updateSubmodules(target, opts))
-    .then(() => git(['rev-parse', '--revs-only', 'HEAD']))
-    .then(({ stdout }) => stdout.trim())
 }


### PR DESCRIPTION
The specified reference is resolved to a `revDoc` by `resolveRef` which uses a separate call to `git ls-remote`

The `revDoc` is then used to return the cloned commit `revDoc.sha` for all handlers except `unresolved`.

This unifies all strategies by always returning the output of `git rev-parse --revs-only HEAD` after checking out the source.

## References

Related to npm/pacote#439